### PR TITLE
Feature: Added neutral colors

### DIFF
--- a/css/colors.css
+++ b/css/colors.css
@@ -75,6 +75,17 @@
     --givewp-purple-700: #120566;
     --givewp-purple-800: #090040;
     --givewp-purple-900: #03001a;
+    --givewp-neutral-25: #f9fafb;
+    --givewp-neutral-50: #f3f4f6;
+    --givewp-neutral-100: #e5e7eb;
+    --givewp-neutral-200: #d1d5db;
+    --givewp-neutral-300: #9ca0af;
+    --givewp-neutral-400: #6b7280;
+    --givewp-neutral-500: #4b5563;
+    --givewp-neutral-600: #374151;
+    --givewp-neutral-700: #1f2937;
+    --givewp-neutral-800: #111827;
+    --givewp-neutral-900: #060c1a;
     --givewp-grey-5: #fafafa;
     --givewp-grey-25: #f2f2f2;
     --givewp-grey-50: #e6e6e6;


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->


## Description
We currently don't have neutral color palette in our design system, and since this color palette was mostly used in campaigns, I added the neutral color palette to our color styles to maintain consistency with what we have in design and development.


## Affects

Affects the color styles.

## Visuals

Below is the image of the neutral color palette.
![image](https://github.com/user-attachments/assets/3b3c89c7-3d13-460f-b1b6-f0767ac9bdf7)

## Testing Instructions

Install the givewp design system and try out the new colors.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [x] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

